### PR TITLE
Enhance README and source files to include Qeff scoring routines and …

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Auxiliary tools for the Monte Carlo particle transport code
 ### FLUKA user routines ###
 
 - [`fluka_let_scoring/`](fluka_let_scoring/) — `FLUSCW`/`COMSCW` routines for LET-moment
-  scoring (track- and dose-averaged LET) and dirty dose. See its
+  scoring (track- and dose-averaged LET), dirty dose, and Qeff (the material-independent
+  effective-charge quality metric, z_eff²/β²). See its
   [README](fluka_let_scoring/README.md) for the scorer keys and post-processing.
 - [`fluka_source/`](fluka_source/) — `SOURCE` routine sampling a spread-out
   Bragg peak from a spot list.

--- a/fluka_let_scoring/README.md
+++ b/fluka_let_scoring/README.md
@@ -1,8 +1,8 @@
-# FLUKA LET scoring routines
+# FLUKA LET and Qeff scoring routines
 
-FLUKA `FLUSCW` and `COMSCW` user-weighting routines for scoring LET moments, from
-which averaged LET quantities (track-averaged and dose-averaged LET) are reconstructed
-in post-processing.
+FLUKA `FLUSCW` and `COMSCW` user-weighting routines for scoring LET and Qeff moments, from
+which averaged radiation-quality quantities (track-averaged and dose-averaged) are
+reconstructed in post-processing.
 
 These are **user routines**, not a standalone program. You link them into a custom FLUKA
 executable, then activate them from your input file with a `USERWEIG` card.
@@ -19,6 +19,12 @@ References:
 - Dirty dose applied to RBE: Kalholm F, Toma-Dasu I, Traneus E. *'Dirty dose'-based proton
   variable RBE models — performance assessment on in vitro data.* Medical Physics.
   2025;52(2):1311-22.
+- Qeff (the `ALQ1`/`ALQF`/`ALQD`/`ALDQ` scorers): Kalholm F, Grzanka L, Toma-Dasu I,
+  Bassler N. *Modeling RBE with other quantities than LET significantly improves
+  prediction of in vitro cell survival for proton therapy.* Medical Physics.
+  2023;50(1):651-9.
+- Kalholm F, et al. *Novel radiation quality metrics accounting for proton energy spectra
+  for RBE proton models.* Medical Physics. 2024;51(8):5773-82.
 
 ## Quick start
 
@@ -164,6 +170,7 @@ the five light species FLUKA supplies.
 | `H4L1`/`H4L2` | ⁴He / α | everything else | `GETLET`, local |
 | `L6L1`, `L6L2`, `L6FL`, `L6DO` | Li-6 (Z=3, A=6) | everything else | `TRACKR` |
 | `L7L1`, `L7L2`, `L7FL`, `L7DO` | Li-7 (Z=3, A=7) | everything else | `TRACKR` |
+| `ALQ1`, `ALQF`, `ALQD`, `ALDQ` | every charged particle FLUKA transports except e±: p, d, t, ³He, ⁴He, Li **and all heavier fragments** | e±, neutrals, point-like depositions | `QEFCAL` (no material, no stopping-power table) |
 
 Three consequences worth internalising:
 
@@ -190,6 +197,11 @@ All-particle (recommended starting point):
 | `ALW1` | all-particle water LET moment | p, d, t, ³He, ⁴He | water | LET |
 | `ALW2` | all-particle water LET² moment | p, d, t, ³He, ⁴He | water | LET² |
 | `ALWF` | water fluence (`ALW1`/`ALW2` denominator) | p, d, t, ³He, ⁴He | — | 1 |
+| `ALQ1` | all-particle Qeff moment, track-length weighted | charged hadrons + ions (no e±) | *(none)* | Qeff |
+| `ALQF` | all-particle fluence (`ALQ1` denominator) | charged hadrons + ions (no e±) | *(none)* | 1 |
+
+See [Effective-charge radiation quality: Qeff](#effective-charge-radiation-quality-qeff)
+below for `ALQ1`/`ALQF`, and for the `ALQD`/`ALDQ` pair in `COMSCW`.
 
 Protons:
 
@@ -225,6 +237,8 @@ Lithium (via `TRACKR`, because `GETLET` returns zero for transported Li):
 | Key | Meaning | Selection | Weight |
 |---|---|---|---|
 | `ALDD` | dirty dose (LET > 30 MeV cm²/g) | charged hadrons + ions (no e±) | 1 or 0 |
+| `ALQD` | dose weighted by Qeff | charged hadrons + ions (no e±) | Qeff |
+| `ALDQ` | dirty dose (Qeff > 30) | charged hadrons + ions (no e±) | 1 or 0 |
 | `P1DO` | primary-proton dose filter | `JTRACK=1`, `LTRACK=1` | 1 or 0 |
 | `L6DO` | Li-6 dose filter | Z=3, A=6 | 1 or 0 |
 | `L7DO` | Li-7 dose filter | Z=3, A=7 | 1 or 0 |
@@ -246,12 +260,29 @@ Dirty dose is the dose deposited by particles whose LET exceeds a threshold — 
 **30 MeV cm²/g** of unrestricted mass stopping power, equivalently **3 keV/µm in water**.
 It answers "how much of this dose was delivered by high-LET particles?", and pairs
 naturally with the LET scorers above. Heuchel et al. (2024) introduce the dirty/clean dose
-concept and its use in planning for a photon-like dose response, **and discuss the choice
-of threshold** — read it before changing the value. Kalholm et al. (2025) assess
-dirty-dose-based variable-RBE models against in vitro data.
+concept and its use in planning for a photon-like dose response; Kalholm et al. (2025)
+assess dirty-dose-based variable-RBE models against in vitro data.
 
-The threshold is the `DDTHRE` parameter in `COMSCW`, in MeV cm²/g; it is a single named
-constant, so changing it means editing one line and recompiling.
+### The two hardcoded dirty-dose thresholds
+
+There are two dirty-dose scorers, on two different quantities, each with its own hardcoded
+threshold. Both are single named `PARAMETER`s in `COMSCW` — change one line and recompile.
+
+| Scorer | Threshold quantity | Parameter | Value |
+|---|---|---|---|
+| `ALDD` | LET (unrestricted mass stopping power) | `DDTHRE` | **30 MeV cm²/g** = **3 keV/µm in water** |
+| `ALDQ` | Qeff = z_eff²/β² (dimensionless) | `DQTHRE` | **30** |
+
+The two values are both "30" **by construction, not by coincidence** — and they are not the
+same 30. They are different quantities in different units. `DQTHRE` was deliberately
+anchored to `DDTHRE`: a proton at the LET threshold (3 keV/µm in water, i.e. 30 MeV cm²/g,
+T ≈ 16.9 MeV, β ≈ 0.188) has **Qeff ≈ 30** (28.4 measured, rounded up). So for protons the
+two dirty-dose definitions cut at roughly the same place; for heavier ions they do not,
+because Qeff's `z_eff²` and LET's stopping power are different functions of energy. See the
+Qeff section below for the full derivation.
+
+Heuchel et al. (2024) discuss the choice of LET threshold — read it before changing
+`DDTHRE`.
 
 Score it with `ALDD` plus an unfiltered bin of the same generalized particle:
 
@@ -303,6 +334,102 @@ Caveats worth knowing before quoting a number:
 > it is required only "for technical reasons — to be overcome at a later stage". Any valid
 > file will do; `tests/letbio.dat` is a minimal one.
 
+## Effective-charge radiation quality: Qeff
+
+Qeff is a radiation-quality metric, not a LET: it is used the same way (as an RBE proxy,
+and to threshold dirty dose), but computed completely differently.
+
+**Qeff is material-independent and needs no stopping power.** It is a closed-form function
+of the particle's own charge and speed alone — nothing about the medium enters it:
+
+```text
+beta   = v/c
+z_eff  = z * ( 1 - exp( -125 * beta * |z|^(-2/3) ) )     (Barkas)
+Qeff   = z_eff^2 / beta^2
+```
+
+That is the fundamental difference from every LET key in this file: LET is a stopping
+power, so it depends on the material and (via `GETLET`) on a per-species table that only
+covers five light ions. Qeff depends on neither.
+
+Kalholm et al. (2023, 2024) show this and related energy/quality metrics improve RBE
+prediction over LET alone for proton therapy; this implementation is not tied to a
+particular RBE model, it just scores the moments needed to reconstruct Qeff and pairs it
+with dirty dose.
+
+Concretely, that material-independence buys two things none of the LET scorers have:
+
+- **One code path for every charged particle**, fragments included, with no `GETLET`
+  coverage gap and no `TRACKR` restricted/unrestricted question — see `QEFCAL` in the
+  source. β comes from `PTRACK/ETRACK` (needs no rest-mass lookup, which is awkward for
+  fragments); z comes from `ICHRGE` for ordinary particles and light ions, or from
+  `FHEAVY` (`ICHEAV`) for heavier fragments transported under FLUKA's generic heavy-ion
+  code `JTRACK = -39` — the same fork the Li scorers already use.
+- **`ALDQ` needs no `IDUSBN` fork.** Compare with `ALDD`, which has to branch on whether
+  the binning is `DOSE` or `DOSE-H2O` because the *material* the LET is judged in changes
+  the answer. Qeff does not care what the binning scores: `ALQD` and `ALDQ` work
+  identically on `DOSE`, `DOSE-H2O`, or any other dose-like generalized particle, with no
+  warning and no restriction.
+
+### Track-averaged and dose-averaged Qeff
+
+Both flavours exist, as for LET, but unlike LET the trick used there (`ALL2/ALL1` for the
+dose average, no dose bin needed) does **not** carry over: it worked because a segment's
+dose *is* `length × LET`, so a second LET moment reproduces the dose weighting for free.
+Qeff carries no such relationship to the energy actually deposited, so the dose-averaged
+flavour has to weight the real dose directly, in `COMSCW`.
+
+Score three co-located bins:
+
+```text
+* Qeff moment, weighted by track length          -> ALQ1  (unit 22)
+USRBIN           11.0  ALL-PART      -22.  <xmax ymax zmax bins...>    ALQ1
+USRBIN         <xmin ymin zmin> ...                                   &
+* unweighted fluence, same particle set          -> ALQF  (unit 21)
+USRBIN           11.0  ALL-PART      -21.  <xmax ymax zmax bins...>    ALQF
+USRBIN         <xmin ymin zmin> ...                                   &
+* dose weighted by Qeff                          -> ALQD  (unit 23)
+USRBIN           10.0      DOSE      -23.  <xmax ymax zmax bins...>    ALQD
+USRBIN         <xmin ymin zmin> ...                                   &
+```
+
+then, paired with an unfiltered `DOSE` bin over the same region:
+
+- **track-averaged Qeff** `= ALQ1 / ALQF`
+- **dose-averaged Qeff** `= ALQD / DOSE`
+
+As always, `ALQF` — not a plain `ALL-PART` bin — is the track-average denominator, for the
+same reason as `ALFL`: it applies exactly the same acceptance as `ALQ1`.
+
+### Dirty dose by Qeff
+
+`ALDQ` is the Qeff analogue of `ALDD`: dose from particles above a threshold, here on Qeff
+rather than on LET.
+
+```text
+* dirty dose, Qeff > 30                          -> ALDQ  (unit 24)
+USRBIN           10.0      DOSE      -24.  <xmax ymax zmax bins...>    ALDQ
+USRBIN         <xmin ymin zmin> ...                                   &
+```
+
+then `dirty fraction = ALDQ / DOSE`, exactly as for `ALDD`.
+
+**On the threshold, 30 (dimensionless):** Qeff and LET are different quantities with
+different units, so their thresholds are independent choices — they cannot, in general,
+be made to agree for every particle and energy. This one was anchored to a proton: at
+30 MeV cm²/g of unrestricted mass stopping power (`ALDD`'s threshold) a proton sits at
+T ≈ 16.9 MeV, β ≈ 0.188, where Qeff ≈ 28.4 (checked against this file's own `ALW1`/`ALWF`
+via `GETLET`). `DQTHRE` is rounded up from that to 30 — slightly *stricter* for protons
+than an exact match would be. The constant is a single named parameter in `COMSCW`
+(`DQTHRE`); changing it means editing one line and recompiling.
+
+As a consistency check, `ALDQ` and `ALDD` were run on the same 160 MeV proton SOBP: the
+resulting dirty-dose fractions track each other closely by depth (e.g. both ≈ 6% at the
+entrance, ≈ 97% at the Bragg peak), with small differences from Bethe's slowly-varying log
+term, which Qeff's pure `1/β²` scaling does not carry. For a heavy fragment the two would
+diverge much more, since Qeff's `z_eff²` dependence and LET's stopping-power `z²`
+dependence are not the same function of energy.
+
 ## A note on ancestry
 
 `LTRACK` gives the generation (1 = source-generation), and the isotope filters classify
@@ -329,8 +456,9 @@ is what `fff` expects. The exact tool names vary between FLUKA distributions (ol
 ## Testing
 
 `tests/` contains a ready-to-run example, `plan01_field01_geoA_SOBPcent.inp`, that
-exercises the scorer keys (proton, light-fragment, and lithium LET moments plus the
-dose/fluence filters). It uses a `SOURCE` reading the accompanying `sobp.dat` spot list,
+exercises the scorer keys (proton, light-fragment, and lithium LET moments, the Qeff
+moments, and the dose/fluence filters). It uses a `SOURCE` reading the accompanying
+`sobp.dat` spot list,
 so the executable must also link the source sampler from `../fluka_source`:
 
 ```bash

--- a/fluka_let_scoring/fluka_let_scoring.f
+++ b/fluka_let_scoring/fluka_let_scoring.f
@@ -43,8 +43,9 @@
       
 
       DOUBLE PRECISION GETLET
-      DOUBLE PRECISION EKIN, LETW, LETLIN, SUMT, SUMD
+      DOUBLE PRECISION EKIN, LETW, LETLIN, SUMT, SUMD, QEFF
       INTEGER MATLET, IHEAV, II, MWATER
+      LOGICAL LQOK
       CHARACTER*8 SCONAM
 
 C
@@ -817,6 +818,47 @@ C        Unweighted fluence over the accepted particle set.
 
          RETURN
       END IF
+
+C     ==================================================================
+C     Track-averaged Qeff = z_eff^2 / beta^2.
+C
+C     Scorer keys:
+C        ALQ1   Qeff moment, weighted by track length
+C        ALQF   unweighted fluence over the SAME particle set
+C
+C     Post-processing:
+C        track-averaged Qeff = ALQ1 / ALQF
+C
+C     For the DOSE-averaged flavour use ALQD in COMSCW -- there is no
+C     ALQ2/ALQ1 shortcut here. That trick works for LET because a
+C     segment's dose is proportional to length*LET, so a second LET
+C     moment reproduces the dose weighting for free. Qeff carries no such
+C     relation to the deposited energy, so the dose average has to be
+C     taken against the energy FLUKA actually deposits, i.e. in COMSCW.
+C
+C     As always, use ALQF and not a plain ALL-PART bin as the denominator:
+C     it applies exactly the same acceptance as ALQ1, so numerator and
+C     denominator cover the same set by construction.
+C
+C     Qeff needs no material and no stopping-power table, so unlike the
+C     LET keys this branch has one code path for every particle, fragments
+C     included. See QEFCAL at the end of this file.
+C     ==================================================================
+
+      IF ( SCONAM(1:4) .EQ. 'ALQ1' .OR. SCONAM(1:4) .EQ. 'ALQF' ) THEN
+         FLUSCW = ZERZER
+
+         CALL QEFCAL ( QEFF, LQOK )
+         IF ( .NOT. LQOK ) RETURN
+
+         IF ( SCONAM(1:4) .EQ. 'ALQF' ) THEN
+            FLUSCW = ONEONE
+         ELSE
+            FLUSCW = QEFF
+         END IF
+
+         RETURN
+      END IF
 C     ------------------------------------------------------------------
 C     Proton FLUSCW branch for LET and primary-proton fluence scoring.
 C
@@ -1047,9 +1089,9 @@ C=======================================================================
       INCLUDE 'fheavy.inc'
 
       DOUBLE PRECISION GETLET
-      DOUBLE PRECISION EKIN, LETW, SUMT, SUMD, SMASS
+      DOUBLE PRECISION EKIN, LETW, SUMT, SUMD, SMASS, QEFF
       INTEGER IHEAV, II, MATLET, MWATER, IDIST
-      LOGICAL DDWARN
+      LOGICAL DDWARN, LQOK
       CHARACTER*8 SCONAM
 
 C     Dirty-dose LET threshold, as unrestricted mass stopping power.
@@ -1058,6 +1100,18 @@ C     The choice of threshold is discussed in Heuchel et al. 2024 (see the
 C     references at the top of this file); consult it before changing this.
       DOUBLE PRECISION DDTHRE
       PARAMETER ( DDTHRE = 30.0D0 )
+
+C     Dirty-dose Qeff threshold, set to sit close to where DDTHRE falls for
+C     a proton. At 30 MeV cm^2/g of unrestricted mass stopping power a
+C     proton is at T ~ 16.9 MeV (beta ~ 0.188), where Qeff = z_eff^2/beta^2
+C     ~ 28.4 (checked with this file's own ALW1/ALWF, against FLUKA's
+C     GETLET). DQTHRE is rounded up from that to the same 30, which is
+C     deliberately slightly stricter for protons rather than looser; the
+C     exact value is not the point -- Qeff and LET are different
+C     quantities, so the two thresholds can only ever agree for one
+C     species at one energy, not in general.
+      DOUBLE PRECISION DQTHRE
+      PARAMETER ( DQTHRE = 30.0D0 )
 
 C     Generalized-particle codes of the two binnings ALDD accepts.
       INTEGER IDDOSE, IDDH2O
@@ -1235,6 +1289,65 @@ C           undefined. Score nothing and say so, once.
          RETURN
       END IF
 
+C     ==================================================================
+C     Dose-averaged Qeff = z_eff^2 / beta^2.
+C
+C     Scorer key:
+C        ALQD   dose weighted by Qeff
+C
+C     Post-processing:
+C        dose-averaged Qeff = ALQD / (unfiltered dose binning, any
+C                              generalized particle: DOSE, DOSE-H2O, ...)
+C
+C     Unlike ALDD, this needs no fork on the binning's generalized particle
+C     and so places no restriction on which one is used: Qeff has no
+C     material dependency at all (see QEFCAL), so "dose weighted by Qeff"
+C     means the same thing regardless of what dose the binning scores.
+C
+C     Also unlike LET, there is no ALQ2/ALQ1 shortcut to reach this from
+C     track-length quantities -- see the note at ALQ1 in FLUSCW for why.
+C     This scorer weights the actual deposited dose directly, in COMSCW,
+C     which is the only way to obtain the dose-averaged flavour honestly.
+C     ==================================================================
+
+      IF ( ISCRNG .EQ. 1 .AND. SCONAM(1:4) .EQ. 'ALQD' ) THEN
+         COMSCW = ZERZER
+
+         CALL QEFCAL ( QEFF, LQOK )
+         IF ( LQOK ) COMSCW = QEFF
+
+         RETURN
+      END IF
+
+C     ==================================================================
+C     Dirty dose by Qeff threshold.
+C
+C     Scorer key:
+C        ALDQ   dose from particles whose Qeff exceeds DQTHRE
+C
+C     The Qeff analogue of ALDD: same "dose from high-quality particles"
+C     idea, but the accept/reject test is on Qeff = z_eff^2/beta^2 rather
+C     than on LET. See DQTHRE above for how the threshold was set.
+C
+C     Post-processing:
+C        dirty fraction = ALDQ / (unfiltered dose binning)
+C
+C     As with ALQD, no material fork is needed or offered: Qeff is the
+C     same number regardless of the medium, so this works identically on a
+C     DOSE or a DOSE-H2O binning (or any other dose-like generalized
+C     particle) without a warning or a restriction. That is the concrete
+C     payoff of a quality metric with no stopping-power table behind it.
+C     ==================================================================
+
+      IF ( ISCRNG .EQ. 1 .AND. SCONAM(1:4) .EQ. 'ALDQ' ) THEN
+         COMSCW = ZERZER
+
+         CALL QEFCAL ( QEFF, LQOK )
+         IF ( LQOK .AND. QEFF .GT. DQTHRE ) COMSCW = ONEONE
+
+         RETURN
+      END IF
+
 C     ------------------------------------------------------------------
 C     Primary-proton DOSE filter for COMSCW.
 C
@@ -1370,6 +1483,92 @@ C
 C     Both FLUSCW and COMSCW need this, so it lives in one place: the
 C     lookup cannot drift between them, and the log line is printed once.
 C=======================================================================
+C=======================================================================
+C Effective-charge radiation quality Qeff, shared by FLUSCW and COMSCW.
+C=======================================================================
+C
+C     Returns QEFF = z_eff^2 / beta^2 for the particle currently being
+C     transported, and LQOK = .TRUE. if it is meaningful for one.
+C
+C        beta   = v/c
+C        z_eff  = z * ( 1 - exp( -125 * beta * |z|^(-2/3) ) )   (Barkas)
+C        QEFF   = z_eff^2 / beta^2                              (dimensionless)
+C
+C     Unlike LET, this needs no material and no stopping-power table: it is
+C     a function of charge and speed alone. It is therefore valid for every
+C     charged particle FLUKA transports, heavy fragments included, and has
+C     no equivalent of the GETLET coverage gap.
+C
+C     beta is taken as PTRACK/ETRACK (momentum over total energy), which is
+C     exact and needs no rest-mass lookup -- convenient for fragments, whose
+C     mass is not addressable through AM.
+C
+C     z is ICHRGE for ordinary particles and light ions (ICHRGE is indexed
+C     from -6, so deuterons through alphas are covered). Heavier fragments
+C     all arrive under the generic JTRACK = -39 with no charge of their own,
+C     so their z comes from FHEAVY instead.
+C
+C     Guards, all of which set LQOK = .FALSE.:
+C        z = 0            neutral: no charge, no Qeff
+C        beta <= 0        would divide by zero. FLUKA enables FP trapping,
+C                         so this must be tested, not left to the hardware.
+C                         (The limit is finite -- z_eff -> 125*beta*z^(1/3)
+C                         as beta -> 0, so QEFF -> 125^2 * z^(2/3) -- but
+C                         the expression itself is 0/0 there.)
+C        JTRACK > NALLWP  point-like deposition pseudo-particle (208 heavy
+C                         recoil, 211 e/gamma below threshold, 308 low
+C                         energy neutron kerma); TRACKR holds no kinematics
+C                         for these.
+C        electrons and positrons (JTRACK = 3, 4) are excluded, matching the
+C        LET scorers: these quantities describe the hadron/ion field.
+C=======================================================================
+      SUBROUTINE QEFCAL ( QEFF, LQOK )
+
+      INCLUDE 'dblprc.inc'
+      INCLUDE 'dimpar.inc'
+      INCLUDE 'iounit.inc'
+      INCLUDE 'trackr.inc'
+      INCLUDE 'paprop.inc'
+      INCLUDE 'fheavy.inc'
+
+      DOUBLE PRECISION QEFF, BETA, ZEFF, ZABS
+      INTEGER IZ, IHEAV
+      LOGICAL LQOK
+
+      QEFF = ZERZER
+      LQOK = .FALSE.
+
+C     Pseudo-particles carry no kinematics: reject before touching TRACKR
+C     or ICHRGE (the latter is only dimensioned (-6:NALLWP)).
+      IF ( JTRACK .GT. NALLWP ) RETURN
+
+C     Charge.
+      IF ( JTRACK .GE. -6 ) THEN
+         IF ( JTRACK .EQ. 3 .OR. JTRACK .EQ. 4 ) RETURN
+         IZ = ICHRGE(JTRACK)
+      ELSE
+         IF ( NPHEAV .LE. 0 ) RETURN
+         IHEAV = KHEAVY(NPHEAV)
+         IF ( IHEAV .LT. 1 .OR. IHEAV .GT. KXHEAV ) RETURN
+         IZ = ICHEAV(IHEAV)
+      END IF
+      IF ( IZ .EQ. 0 ) RETURN
+
+C     Speed.
+      IF ( ETRACK .LE. ZERZER ) RETURN
+      BETA = PTRACK / ETRACK
+      IF ( BETA .LE. ZERZER ) RETURN
+
+      ZABS = DBLE( ABS( IZ ) )
+      ZEFF = DBLE( IZ ) *
+     &       ( ONEONE - EXP( -1.25D+02 * BETA * ZABS**(-TWOTHI) ) )
+
+      QEFF = ( ZEFF * ZEFF ) / ( BETA * BETA )
+      LQOK = .TRUE.
+
+      RETURN
+*=== End of subroutine Qefcal =========================================*
+      END
       SUBROUTINE LETMWA ( MWATER )
 
       INCLUDE 'dblprc.inc'

--- a/fluka_let_scoring/fluka_let_scoring.f
+++ b/fluka_let_scoring/fluka_let_scoring.f
@@ -1464,26 +1464,6 @@ C     ------------------------------------------------------------------
 *=== End of function Comscw ===========================================*
       END
 C=======================================================================
-C Water material lookup, shared by FLUSCW and COMSCW.
-C=======================================================================
-C
-C     Returns in MWATER the material index to use for the water-reference
-C     scorers. Resolved once, on the first call, and cached; the result is
-C     written to the FLUKA output (LUNOUT) so it can be verified.
-C
-C     MWATER is resolved as:
-C        1. MATQLT -- FLUKA's built-in "extra water material for Q(L)
-C           calculations" (flkmat.inc). This exists for dose-equivalent /
-C           quality-factor scoring and is available even when the input
-C           deck defines no explicit WATER material.
-C        2. otherwise, the first material named 'WATER' in MATNAM.
-C        3. otherwise MWATER stays .LE. 0 and the water-reference scorers
-C           return zero (a warning is written to LUNOUT).
-C
-C     Both FLUSCW and COMSCW need this, so it lives in one place: the
-C     lookup cannot drift between them, and the log line is printed once.
-C=======================================================================
-C=======================================================================
 C Effective-charge radiation quality Qeff, shared by FLUSCW and COMSCW.
 C=======================================================================
 C
@@ -1559,6 +1539,9 @@ C     Speed.
       BETA = PTRACK / ETRACK
       IF ( BETA .LE. ZERZER ) RETURN
 
+C     TWOTHI is FLUKA's own named constant for 2/3 (dblprc.inc, alongside
+C     ONEONE and ZERZER); ZABS**(-TWOTHI) is the Barkas z^(-2/3). It is not
+C     a local variable -- do not "define it" or inline it as 2.0D0/3.0D0.
       ZABS = DBLE( ABS( IZ ) )
       ZEFF = DBLE( IZ ) *
      &       ( ONEONE - EXP( -1.25D+02 * BETA * ZABS**(-TWOTHI) ) )
@@ -1569,6 +1552,26 @@ C     Speed.
       RETURN
 *=== End of subroutine Qefcal =========================================*
       END
+C=======================================================================
+C Water material lookup, shared by FLUSCW and COMSCW.
+C=======================================================================
+C
+C     Returns in MWATER the material index to use for the water-reference
+C     scorers. Resolved once, on the first call, and cached; the result is
+C     written to the FLUKA output (LUNOUT) so it can be verified.
+C
+C     MWATER is resolved as:
+C        1. MATQLT -- FLUKA's built-in "extra water material for Q(L)
+C           calculations" (flkmat.inc). This exists for dose-equivalent /
+C           quality-factor scoring and is available even when the input
+C           deck defines no explicit WATER material.
+C        2. otherwise, the first material named 'WATER' in MATNAM.
+C        3. otherwise MWATER stays .LE. 0 and the water-reference scorers
+C           return zero (a warning is written to LUNOUT).
+C
+C     Both FLUSCW and COMSCW need this, so it lives in one place: the
+C     lookup cannot drift between them, and the log line is printed once.
+C=======================================================================
       SUBROUTINE LETMWA ( MWATER )
 
       INCLUDE 'dblprc.inc'

--- a/tests/plan01_field01_geoA_SOBPcent.inp
+++ b/tests/plan01_field01_geoA_SOBPcent.inp
@@ -176,6 +176,18 @@ USRBIN         -1.00     -1.00    -10.25       1.0       1.0     205.0       &
 * unfiltered dose-to-water, the denominator for ALDD_WZ
 USRBIN          10.0     252.0     -76.0      1.00      1.00     10.25      DSW_ZN
 USRBIN         -1.00     -1.00    -10.25       1.0       1.0     205.0       &
+* Qeff = z_eff^2/beta^2 (Barkas), no material dependency at all.
+* Track-averaged Qeff = ALQ1 / ALQF
+USRBIN          10.0     201.0     -77.0      1.00      1.00     10.25      ALQ1_ZN
+USRBIN         -1.00     -1.00    -10.25       1.0       1.0     205.0       &
+USRBIN          10.0     201.0     -78.0      1.00      1.00     10.25      ALQF_ZN
+USRBIN         -1.00     -1.00    -10.25       1.0       1.0     205.0       &
+* Dose-averaged Qeff = ALQD / DOSE_ZN (u21)
+USRBIN          10.0     228.0     -79.0      1.00      1.00     10.25      ALQD_DZ
+USRBIN         -1.00     -1.00    -10.25       1.0       1.0     205.0       &
+* Dirty dose by Qeff threshold: dirty fraction = ALDQ / DOSE_ZN (u21)
+USRBIN          10.0     228.0     -80.0      1.00      1.00     10.25      ALDQ_DZ
+USRBIN         -1.00     -1.00    -10.25       1.0       1.0     205.0       &
 USERWEIG         0.0       0.0       1.0       0.0       0.0       1.0
 * DOSE-H2O needs a RAD-BIOL card present; its alpha/beta content is not
 * used for dose-to-water (FLUKA developers confirm), but omitting the


### PR DESCRIPTION
…thresholds

- Updated README.md to clarify the addition of Qeff scoring routines alongside LET scoring.
- Modified fluka_let_scoring.f to implement track-averaged and dose-averaged Qeff calculations.
- Added relevant comments and parameters for Qeff thresholds in the source code.
- Updated test input file to include USRBIN entries for Qeff scoring and dirty dose calculations.